### PR TITLE
Update httpx to use HTTP/2 extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project contains a FastAPI backend and a Next.js frontend.
 ## Backend
 
 1. Create a virtual environment and activate it.
-2. Install dependencies:
+2. Install dependencies (includes HTTP/2 support for httpx):
    ```bash
    pip install -r requirements.txt
    ```

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,6 @@ sqlalchemy
 psycopg2-binary
 pandas
 openpyxl
-httpx
+httpx[http2]
 beautifulsoup4
 rapidfuzz

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ sqlalchemy
 psycopg2-binary
 pandas
 openpyxl
-httpx
+httpx[http2]
 beautifulsoup4
 rapidfuzz


### PR DESCRIPTION
## Summary
- enable HTTP/2 support in httpx dependencies
- mention HTTP/2 support in backend install instructions

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6870176518fc8328aeee33c8936f82e5